### PR TITLE
keep while-let from ever acting on non-truthy values

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject while-let "0.1.0"
+(defproject while-let "0.2.0"
     :description "Repeatedly executes body while test expression is true, evaluating the body with binding-form bound to the value of test."
     :url "https://github.com/markmandel/while-let"
     :license {:name "Eclipse Public License"

--- a/src/while_let/core.clj
+++ b/src/while_let/core.clj
@@ -6,6 +6,6 @@
     [bindings & body]
     (let [form (first bindings) test (second bindings)]
         `(loop [~form ~test]
-             ~@body
              (when ~form
+                 ~@body
                  (recur ~test)))))

--- a/test/while_let/core_test.clj
+++ b/test/while_let/core_test.clj
@@ -6,8 +6,7 @@
       (macroexpand
           '(while-let [form test]
                       (body))) => '(loop* [form test]
-                                          (body)
-                                          (clojure.core/when form (recur test)))
+                                          (clojure.core/when form (body) (recur test)))
       )
 
 (fact "Should continue to loop until the vector is empty"
@@ -17,3 +16,8 @@
                      (swap! data rest))
           (empty? @data) => true))
 
+(fact "Should never act on false or nil"
+      (let [data (atom [1 2 3 4 5])]
+          (while-let [item (first @data)]
+                     (boolean item) => true
+                     (swap! data rest))))


### PR DESCRIPTION
thanks for this!  just moved the `~@body` to be inside the `when` block, as per normal `while` behavior.
