### PR TITLE
Correctly handle complex pattern match

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
     :url "https://github.com/markmandel/while-let"
     :license {:name "Eclipse Public License"
               :url  "http://www.eclipse.org/legal/epl-v10.html"}
-    :dependencies [[org.clojure/clojure "1.6.0"]]
+    :dependencies [[org.clojure/clojure "1.10.3"]]
     :plugins [[lein-midje "3.1.3"]]
-    :profiles {:dev {:dependencies [[midje "1.6.3"]
+    :profiles {:dev {:dependencies [[midje "1.10.3"]
                                     [org.clojure/tools.namespace "0.2.7"]]
                      :source-paths ["dev"]
                      :repl-options {:init-ns user}}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject while-let "0.2.0"
+(defproject while-let "0.3.0"
     :description "Repeatedly executes body while test expression is true, evaluating the body with binding-form bound to the value of test."
     :url "https://github.com/markmandel/while-let"
     :license {:name "Eclipse Public License"

--- a/src/while_let/core.clj
+++ b/src/while_let/core.clj
@@ -4,7 +4,7 @@
 (defmacro while-let
     "Repeatedly executes body while test expression is true, evaluating the body with binding-form bound to the value of test."
     [[form test] & body]
-    `(loop [~form ~test]
-         (when ~form
+    `(loop []
+       (when-let [~form ~test]
              ~@body
-             (recur ~test))))
+             (recur))))

--- a/test/while_let/core_test.clj
+++ b/test/while_let/core_test.clj
@@ -21,3 +21,9 @@
           (while-let [item (first @data)]
                      (boolean item) => true
                      (swap! data rest))))
+
+(fact "Should correctly handle complex pattern match"
+      (let [data (atom [{:item :test}])]
+        (while-let [{:keys [item]} (first @data)]
+                   item => :test
+                   (swap! data rest))))

--- a/test/while_let/core_test.clj
+++ b/test/while_let/core_test.clj
@@ -5,9 +5,8 @@
 (fact "Macro expand of while-let should be in the format I expect"
       (macroexpand
           '(while-let [form test]
-                      (body))) => '(loop* [form test]
-                                          (clojure.core/when form (body) (recur test)))
-      )
+                      (body))) => '(loop* []
+                                          (clojure.core/when-let [form test] (body) (recur))))
 
 (fact "Should continue to loop until the vector is empty"
       (let [data (atom [1 2 3 4 5])]


### PR DESCRIPTION
`while-let` behaves in a surprising way when the pattern it is given is not simple, when compared to other similar macros such as `when-let`.  For example, compare the output of this `when-let`:

```clojure
(when-let [{:keys [foo]} nil]
  (println "Not reached"))
```

with the output of this `while-let`:

```clojure
(while-let [{:keys [foo]} nil]
  (println "BUG!"))
```

In first case, the body is not executed.  In the second case, it is executed infinitely

This is because `while-let` checks the truth of the expression on the right, whereas `while-let` checks the truth of the expression on the left.  When the expression on the left is a simple pattern (which is the most common case) these are equivalent.  But in the case above, the expression on the left is true regardless of what is returned by the expression on the right.

I am raising this PR to address this issue.